### PR TITLE
Setting BCH component depth parameter

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -3,3 +3,7 @@ component_depth: 2
 
 languages:
 - python
+
+exclude:
+- /website/giphousewebsite/settings.py
+- /website/.*/migrations/


### PR DESCRIPTION
The "Keep Architecture Components Balanced" guideline of BCH currently fails, because the entire project is seen as a single, monolithic component. By setting an appropriate zoom level, as suggested by the "Configure zoom level" tab in BCH, multiple top-level components are recognised.