### PR TITLE
Remove unnecessary middleware

### DIFF
--- a/website/giphousewebsite/settings/production.py
+++ b/website/giphousewebsite/settings/production.py
@@ -46,13 +46,11 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'giphousewebsite.urls'


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Remove unnecessary middleware.

### Description
<!-- Describe in detail why this pull request is needed. -->
`SecurityMiddleware` and `XFrameOptionsMiddleware` provide security HTTP headers (if enabled) that we already supply via `nginx`. Which makes it unnecessary in the Django config.