### PR TITLE
Correctly parse linebreaks in lecture descriptions

### DIFF
--- a/website/courses/templates/courses/index.html
+++ b/website/courses/templates/courses/index.html
@@ -47,7 +47,7 @@
                                     </table>
 
                                     {% if lecture.description %}
-                                        {{ lecture.description }}
+                                        {{ lecture.description|linebreaks }}
                                     {% endif %}
                                 </div>
                             </div>


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Correctly parse linebreaks in lecture descriptions.