### PR TITLE
Allow peers to be [] in questionnaire

### DIFF
--- a/website/peer_review/views.py
+++ b/website/peer_review/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import redirect, get_object_or_404, get_list_or_404
+from django.shortcuts import redirect, get_object_or_404
 from django.contrib import messages
 from django.utils import timezone
 from django.views.generic import ListView
@@ -36,7 +36,7 @@ class PeerReviewView(LoginRequiredMixin, FormView):
         """Set up the objects used in this form."""
         self.questionnaire = get_object_or_404(Questionnaire, pk=questionnaire)
         self.participant = self.request.user
-        self.peers = get_list_or_404(users_in_same_group(self.participant))
+        self.peers = users_in_same_group(self.participant)
         self.questions = Question.objects.filter(questionnaire=self.questionnaire)
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Allow `peers` to be `[]` in questionnaire.