### PR TITLE
Enforce room reservations to be in time range

### DIFF
--- a/website/room_reservation/forms.py
+++ b/website/room_reservation/forms.py
@@ -64,6 +64,10 @@ class ReservationForm(ModelForm):
             raise ValidationError(
                 'start time past or same as end time. Please enter a valid time range.', code='invalid')
 
+        if start_time.hour < 8 or start_time.hour >= 18 or end_time.hour < 8 or start_time.hour > 18:
+            raise ValidationError(
+                    'reservation outside range, Please enter times between 8:00 and 18:00.', code='invalid')
+
     def __init__(self, *args, **kwargs):
         """Initialize the object and give user-friendly widgets for the datetime objects."""
         super().__init__(*args, **kwargs)

--- a/website/room_reservation/tests/test_forms.py
+++ b/website/room_reservation/tests/test_forms.py
@@ -47,6 +47,15 @@ class PeerReviewTest(TestCase):
         form = ReservationForm(data=form_data)
         self.assertFalse(form.is_valid())
 
+    def test_ReservationForm_out_of_range(self):
+        form_data = {
+            'room': str(self.room.pk),
+            'start_time': "2005-7-14 6:00",
+            'end_time': "2005-7-14 10:00",
+        }
+        form = ReservationForm(data=form_data)
+        self.assertFalse(form.is_valid())
+
     def test_ReservationForm_end_time_past_start_time(self):
         form_data = {
             'room': str(self.room.pk),

--- a/website/room_reservation/tests/test_views.py
+++ b/website/room_reservation/tests/test_views.py
@@ -62,8 +62,8 @@ class PeerReviewTest(TestCase):
             reverse('room_reservation:create_reservation'),
             {
                 'room': self.room.pk,
-                'start_time': "04/17/2019 18:00",
-                'end_time': "04/17/2019 19:00",
+                'start_time': "04/17/2019 10:00",
+                'end_time': "04/17/2019 12:00",
             },
             follow=True,
         )


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #239

### Description
Rooms cannot be reserved out of the range of the calendar.
Reservation can only be reserved in the time range of 8:00 between 18:00.
