### PR TITLE
Show projects for latest registration in User admin

### DIFF
--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -117,7 +117,7 @@ class StudentAdminForm(forms.ModelForm):
     )
 
     project = forms.ModelChoiceField(
-        queryset=Project.objects.filter(semester=Semester.objects.get_current_registration()),
+        queryset=Project.objects.all(),
         required=False,
     )
 
@@ -126,8 +126,13 @@ class StudentAdminForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields['role'].initial = Role.objects.filter(user=self.instance).first()
-
         self.fields['project'].initial = Project.objects.filter(user=self.instance).first()
+
+        user_registration = self.instance.registration_set.order_by('-semester').first()
+        if user_registration is not None:
+            self.fields['project'].queryset = Project.objects.filter(
+                semester=user_registration.semester
+            )
 
     def save_m2m(self):
         """Add the user to the specified groups."""

--- a/website/registrations/tests/test_admin.py
+++ b/website/registrations/tests/test_admin.py
@@ -37,10 +37,11 @@ class RegistrationAdminTest(TestCase):
             }
         )
         project = Project.objects.create(
-            name="GiPHouse",
+            name="GiPHouse1234",
             description="Test",
             semester=semester,
         )
+
         cls.manager = User.objects.create(username='manager')
         GiphouseProfile.objects.create(
             user=cls.manager,
@@ -73,7 +74,7 @@ class RegistrationAdminTest(TestCase):
             '_save': 'Save'
         }
 
-        Registration.objects.create(
+        cls.registration = Registration.objects.create(
             user=cls.manager,
             semester=semester,
             preference1=project,
@@ -111,6 +112,12 @@ class RegistrationAdminTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(User.objects.get(giphouseprofile__student_number='s1111111'))
 
+    def test_project_queryset_contains_projects_from_registration_semester(self):
+        response = self.client.get(
+            reverse('admin:auth_user_change', args=[self.manager.pk]),
+        )
+        self.assertContains(response, 'GiPHouse1234')
+
     def test_place_in_first_project_preference(self):
         response = self.client.post(
             reverse('admin:auth_user_changelist'),
@@ -122,3 +129,5 @@ class RegistrationAdminTest(TestCase):
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
+        project = Project.objects.filter(user=self.manager).first()
+        self.assertEqual(project, self.registration.preference1)


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Show projects for latest registration in User admin

### Description
<!-- Describe in detail why this pull request is needed. -->
Previously the projects for the semester with open registration was shown, which is not always the correct semester