### PR TITLE
Show alert if no peers in questionnaire

### DIFF
--- a/website/questionnaires/forms.py
+++ b/website/questionnaires/forms.py
@@ -7,7 +7,7 @@ from questionnaires.models import QuestionnaireSubmission
 class QuestionnaireForm(forms.Form):
     """Dynamic form generating a questionnaires form."""
 
-    def __init__(self, participant, questionnaire, peers, *args, **kwargs):
+    def __init__(self, participant, questionnaire, peers, no_peers_warning, *args, **kwargs):
         """Dynamically setup form."""
         super().__init__(*args, **kwargs)
 
@@ -15,6 +15,7 @@ class QuestionnaireForm(forms.Form):
         self.questionnaire = questionnaire
         self.questions = questionnaire.question_set.all()
         self.peers = peers
+        self.no_peers_warning = no_peers_warning
 
         for question in self.questions:
             if question.about_team_member:

--- a/website/questionnaires/templates/questionnaires/questionnaire.html
+++ b/website/questionnaires/templates/questionnaires/questionnaire.html
@@ -6,6 +6,9 @@
 {% endblock %}
 
 {% block content %}
+  {% if form.no_peers_warning %}
+    <p class="text-danger">This questionnaire contains questions about your team members, but you are either not in a project, or your project has no other peers.</p>
+  {% endif %}
 	<h1 class="mt-2">{{form.questionnaire.title}}</h1>
     {% bootstrap_form_errors form %}
     <form method="post" class="row">

--- a/website/questionnaires/views.py
+++ b/website/questionnaires/views.py
@@ -63,6 +63,9 @@ class QuestionnaireView(LoginRequiredMessageMixin, FormView):
                     groups__in=participant.groups.filter(project__semester=Semester.objects.get_current_semester())
                 )
         )
+        kwargs['no_peers_warning'] = (
+                questionnaire.question_set.filter(about_team_member=True).exists() and not kwargs['peers']
+        )
 
         return kwargs
 


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #298

### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Show alert if no peers in questionnaire

### Description
<!-- Describe in detail why this pull request is needed. -->
A questionnaire page now shows a red warning message to signify the user won't be able to test/fill in questions about peers.