### PR TITLE
Add a check to only catch uniqueness constraint violations in the createfixtures command

### DIFF
--- a/website/giphousewebsite/management/commands/createfixtures.py
+++ b/website/giphousewebsite/management/commands/createfixtures.py
@@ -273,5 +273,7 @@ class Command(BaseCommand):
                         self.__getattribute__('create_' + thing)()
                         break
                     except IntegrityError as e:
-                        print(e)
-                        self.stderr.write("IntegrityError, trying again")
+                        if 'UNIQUE constraint failed' in str(e.__cause__):
+                            self.stderr.write("IntegrityError, trying again")
+                        else:
+                            raise


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Add a check to only catch uniqueness constraint violations in the createfixtures command

### Description
<!-- Describe in detail why this pull request is needed. -->
The `while True` in the `createfixtures` is meant to retry if it randomly tried to create an existing record. It should not retry if another type of `IntegrityError` is thrown.