### PR TITLE
Make tests season aware

### DIFF
--- a/website/projects/tests/test_views.py
+++ b/website/projects/tests/test_views.py
@@ -2,7 +2,7 @@ from django.shortcuts import reverse
 from django.test import Client, TestCase
 from django.utils import timezone
 
-from courses.models import Semester
+from courses.models import Semester, current_season
 
 
 class GetProjectsTest(TestCase):
@@ -10,7 +10,7 @@ class GetProjectsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
 
-        cls.season = Semester.SPRING
+        cls.season = current_season()
         cls.year = 2019
 
         cls.semester = Semester.objects.create(

--- a/website/questionnaires/tests/test_admin.py
+++ b/website/questionnaires/tests/test_admin.py
@@ -4,9 +4,7 @@ from django.shortcuts import reverse
 from django.test import Client, TestCase
 from django.utils import timezone
 
-from freezegun import freeze_time
-
-from courses.models import Semester
+from courses.models import Semester, current_season
 
 from projects.models import Project
 
@@ -29,7 +27,6 @@ User: DjangoUser = get_user_model()
 class QuestionnaireTest(TestCase):
 
     @classmethod
-    @freeze_time("2019-01-01")
     def setUpTestData(cls):
         cls.admin_password = 'hunter2'
         cls.admin = User.objects.create_superuser(
@@ -39,7 +36,7 @@ class QuestionnaireTest(TestCase):
 
         cls.semester = Semester.objects.create(
             year=2019,
-            season=Semester.SPRING,
+            season=current_season(),
             registration_start=timezone.now(),
             registration_end=timezone.now() + timezone.timedelta(days=60)
         )
@@ -120,7 +117,6 @@ class QuestionnaireTest(TestCase):
         self.client = Client()
         self.client.login(username=self.admin.username, password=self.admin_password)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -128,7 +124,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist_averagefilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -139,7 +134,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist_averagefilter_below(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -150,7 +144,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist_semesterfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -161,7 +154,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist_projectfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -172,7 +164,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_submission_changelist_peerfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_changelist'),
@@ -183,7 +174,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_view_submission_object(self):
         response = self.client.get(
             reverse('admin:questionnaires_questionnairesubmission_change', kwargs={'object_id': self.submission.id}),
@@ -191,7 +181,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),
@@ -199,7 +188,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist_questionnairefilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),
@@ -210,7 +198,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist_projectfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),
@@ -221,7 +208,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist_participantfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),
@@ -232,7 +218,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist_valuefilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),
@@ -243,7 +228,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_answer_changelist_semesterfilter(self):
         response = self.client.get(
             reverse('admin:questionnaires_answer_changelist'),

--- a/website/questionnaires/tests/test_views.py
+++ b/website/questionnaires/tests/test_views.py
@@ -4,9 +4,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from freezegun import freeze_time
-
-from courses.models import Semester
+from courses.models import Semester, current_season
 
 from projects.models import Project
 
@@ -35,12 +33,11 @@ def generate_post_data(questionnaire_id, peers):
 class QuestionnaireTest(TestCase):
 
     @classmethod
-    @freeze_time("2019-01-01")
     def setUpTestData(cls):
 
         semester = Semester.objects.create(
             year=2019,
-            season=Semester.SPRING,
+            season=current_season(),
             registration_start=timezone.now(),
             registration_end=timezone.now() + timezone.timedelta(days=60)
         )
@@ -122,20 +119,17 @@ class QuestionnaireTest(TestCase):
         self.client = Client()
         self.client.login(username='myself', password='123')
 
-    @freeze_time("2019-01-01")
     def test_get_overview(self):
         response = self.client.get(reverse('questionnaires:overview'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Start Late')
 
-    @freeze_time("2019-01-01")
     def test_get_questionnaire(self):
         response = self.client.get(
             reverse('questionnaires:questionnaire', kwargs={'questionnaire': self.active_questions.id})
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_post_questionnaire(self):
         current_peers = User.objects.exclude(pk=self.user.pk)
         post_data = generate_post_data(self.active_questions.id, current_peers)
@@ -147,7 +141,6 @@ class QuestionnaireTest(TestCase):
         )
         self.assertRedirects(response, reverse('home'))
 
-    @freeze_time("2019-01-01")
     def test_post_questionnaire_twice(self):
 
         current_peers = User.objects.exclude(pk=self.user.pk)
@@ -169,7 +162,6 @@ class QuestionnaireTest(TestCase):
 
         self.assertContains(response, 'Questionnaire already submitted.')
 
-    @freeze_time("2019-01-01")
     def test_post_closed(self):
 
         response = self.client.post(
@@ -179,21 +171,18 @@ class QuestionnaireTest(TestCase):
         )
         self.assertEquals(response.status_code, 404)
 
-    @freeze_time("2019-01-01")
     def test_get_closed_questionnaire(self):
         response = self.client.get(
             reverse('questionnaires:questionnaire', kwargs={'questionnaire': self.closed_questions.id}),
         )
         self.assertEquals(response.status_code, 404)
 
-    @freeze_time("2019-01-01")
     def test_all_questionnaires_visible(self):
         response = self.client.get(reverse('questionnaires:overview'))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.active_questions.title)
         self.assertContains(response, self.closed_questions.title)
 
-    @freeze_time("2019-01-01")
     def test_warning_message_not_shown_when_user_is_in_team(self):
         response = self.client.get(
             reverse('questionnaires:questionnaire', kwargs={'questionnaire': self.active_questions.id})
@@ -201,7 +190,6 @@ class QuestionnaireTest(TestCase):
         self.assertNotContains(response, "This questionnaire contains questions about your team members, "
                                          "but you are either not in a project, or your project has no other peers.")
 
-    @freeze_time("2019-01-01")
     def test_warning_message_shown_when_user_is_alone(self):
         self.client.login(username='loner', password='123')
         response = self.client.get(

--- a/website/registrations/forms.py
+++ b/website/registrations/forms.py
@@ -32,9 +32,9 @@ class Step2Form(forms.Form):
             (sdm.id, 'System Development Management'),
         )
 
-        self.fields['project1'].queryset = Project.objects.filter(semester=Semester.objects.get_current_registration())
-        self.fields['project2'].queryset = Project.objects.filter(semester=Semester.objects.get_current_registration())
-        self.fields['project3'].queryset = Project.objects.filter(semester=Semester.objects.get_current_registration())
+        self.fields['project1'].queryset = Project.objects.filter(semester=Semester.objects.get_current_semester())
+        self.fields['project2'].queryset = Project.objects.filter(semester=Semester.objects.get_current_semester())
+        self.fields['project3'].queryset = Project.objects.filter(semester=Semester.objects.get_current_semester())
 
     first_name = forms.CharField(widget=widgets.TextInput(attrs={'class': 'form-control'}))
     last_name = forms.CharField()

--- a/website/registrations/tests/test_admin.py
+++ b/website/registrations/tests/test_admin.py
@@ -5,9 +5,7 @@ from django.shortcuts import reverse
 from django.test import Client, TestCase
 from django.utils import timezone
 
-from freezegun import freeze_time
-
-from courses.models import Semester
+from courses.models import Semester, current_season
 
 from projects.models import Project
 
@@ -20,7 +18,6 @@ User: DjangoUser = get_user_model()
 class RegistrationAdminTest(TestCase):
 
     @classmethod
-    @freeze_time("2019-01-01")
     def setUpTestData(cls):
         cls.admin_password = 'hunter2'
         cls.admin = User.objects.create_superuser(
@@ -32,7 +29,7 @@ class RegistrationAdminTest(TestCase):
         sdm, _ = Role.objects.get_or_create(name=Role.SDM)
         cls.semester, _ = Semester.objects.get_or_create(
             year=timezone.now().year,
-            season=Semester.SPRING,
+            season=current_season(),
             defaults={
                 'registration_start': timezone.now() - timezone.timedelta(days=30),
                 'registration_end': timezone.now() + timezone.timedelta(days=30),
@@ -95,7 +92,6 @@ class RegistrationAdminTest(TestCase):
         self.client = Client()
         self.client.login(username=self.admin.username, password=self.admin_password)
 
-    @freeze_time("2019-01-01")
     def test_get_changelist(self):
         response = self.client.get(
             reverse('admin:registrations_student_changelist'),
@@ -157,7 +153,6 @@ class RegistrationAdminTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @freeze_time("2019-01-01")
     def test_get_student_changelist_project_filter(self):
         response = self.client.get(
             reverse('admin:registrations_student_changelist'),

--- a/website/registrations/tests/test_models.py
+++ b/website/registrations/tests/test_models.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User as DjangoUser
 from django.test import TestCase
 from django.utils import timezone
 
-from courses.models import Semester
+from courses.models import Semester, current_season
 
 from projects.models import Project
 
@@ -34,7 +34,7 @@ class ModelsTest(TestCase):
 
         cls.test_semester = Semester.objects.create(
             year=timezone.now().year,
-            season=Semester.SPRING,
+            season=current_season(),
             registration_start=timezone.now(),
             registration_end=timezone.now() + timezone.timedelta(days=1),
         )

--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -27,7 +27,8 @@ class Step1View(TemplateView):
             messages.warning(request, "You are already logged in", extra_tags='success')
             return redirect('home')
 
-        if not Semester.objects.get_current_registration():
+        if (Semester.objects.get_current_semester() is None
+                or not Semester.objects.get_current_semester().registration_open()):
             messages.warning(request, "Registrations are currently not open", extra_tags='danger')
             return redirect('home')
 
@@ -109,7 +110,7 @@ class Step2View(FormView):
 
             Registration.objects.create(
                 user=user,
-                semester=Semester.objects.get_current_registration().first(),
+                semester=Semester.objects.get_current_semester(),
                 experience=form.cleaned_data['experience'],
                 preference1=form.cleaned_data['project1'],
                 preference2=form.cleaned_data['project2'],


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Make tests season aware.

### Description
<!-- Describe in detail why this pull request is needed. -->
Because the spring and fall semester should not differ, creating a test using the current season is fine.

This PR also removes `get_current_registration`. Now only the current semester can have an open registration.