### PR TITLE
Use stdout instead of stderr to write createfixtures logs

### DIFF
--- a/website/giphousewebsite/management/commands/createfixtures.py
+++ b/website/giphousewebsite/management/commands/createfixtures.py
@@ -253,10 +253,10 @@ class Command(BaseCommand):
         options = dict()
 
         if all([value is None for key, value in kwargs.items() if key in THINGS]) or kwargs['merge']:
-            self.stderr.write("Applying default options")
+            self.stdout.write("Applying default options")
             options = DEFAULTS
         else:
-            self.stderr.write("Only using user options")
+            self.stdout.write("Only using user options")
 
         for key, value in kwargs.items():
             if value is not None:


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Use `stdout` instead of `stderr` to write `createfixtures` logs.

### Description
<!-- Describe in detail why this pull request is needed. -->
This makes Travis CI logs a bit more readable, because only actual errors are shown in red.
