### PR TITLE
Use empty Github OAuth secrets in dev settings if they are not found

### DIFF
--- a/website/giphousewebsite/settings/development.py
+++ b/website/giphousewebsite/settings/development.py
@@ -29,5 +29,5 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
 # GitHub OAuth Settings
-GITHUB_CLIENT_ID = os.environ.get('GITHUB_CLIENT_ID')
-GITHUB_CLIENT_SECRET = os.environ.get('GITHUB_CLIENT_SECRET')
+GITHUB_CLIENT_ID = os.environ.get('GITHUB_CLIENT_ID', '')
+GITHUB_CLIENT_SECRET = os.environ.get('GITHUB_CLIENT_SECRET', '')


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Use empty Github OAuth secrets in dev settings if they are not found.