### PR TITLE
Use assertEqual instead of the deprecated assertEquals

### DIFF
--- a/website/questionnaires/tests/test_mixins.py
+++ b/website/questionnaires/tests/test_mixins.py
@@ -13,4 +13,4 @@ class LoginRequiredMessageMixinTest(TestCase):
 
         mixin = LoginRequiredMessageMixin()
         self.assertRedirects(response, f"{mixin.get_login_url()}?next={reverse('questionnaires:overview')}")
-        self.assertEquals(list(map(str, response.context["messages"])), [mixin.message])
+        self.assertEqual(list(map(str, response.context["messages"])), [mixin.message])

--- a/website/questionnaires/tests/test_views.py
+++ b/website/questionnaires/tests/test_views.py
@@ -165,13 +165,13 @@ class QuestionnaireTest(TestCase):
             {},
             follow=True,
         )
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_closed_questionnaire(self):
         response = self.client.get(
             reverse("questionnaires:questionnaire", kwargs={"questionnaire": self.closed_questions.id})
         )
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_all_questionnaires_visible(self):
         response = self.client.get(reverse("questionnaires:overview"))


### PR DESCRIPTION
### One-sentence description
Use `assertEqual` instead of the deprecated `assertEquals`.