### PR TITLE
Use --quiet on black

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         poetry install
 
     - name: "Run Black"
-      run: "poetry run black --check website"
+      run: "poetry run black --quiet --check website"
 
     - name: "Run flake8"
       run: >-


### PR DESCRIPTION
### One-sentence description
Use `--quiet` on `black` to disable unnecessary output.