### PR TITLE
Use an authorization header instead of a query parameter for GitHub OAuth authentication

### DIFF
--- a/website/github_oauth/backends.py
+++ b/website/github_oauth/backends.py
@@ -69,7 +69,7 @@ class GithubOAuthBackend(ModelBackend):
 
         try:
             response = requests.get(
-                URL_GITHUB_USER_INFO, params={"access_token": access_token}, headers={"Accept": "application/json"}
+                URL_GITHUB_USER_INFO, headers={"Accept": "application/json", "Authorization": f"token {access_token}"}
             )
         except RequestException:
             raise GithubOAuthConnectionError


### PR DESCRIPTION
### Description
<!-- Describe in detail why this pull request is needed. -->
Passing the `access_token`  as a query parameter in GitHub OAuth is [deprecated](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters). This PR replaces it with the [authorization header](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#3-use-the-access-token-to-access-the-api).