### PR TITLE
Remove empty Media subclasses that are no longer necessary for django-admin-autocomplete-filter

### DIFF
--- a/website/questionnaires/admin.py
+++ b/website/questionnaires/admin.py
@@ -125,9 +125,6 @@ class QuestionnaireSubmissionAdmin(admin.ModelAdmin):
         response["Content-Disposition"] = "attachment; filename=submissions.csv"
         return response
 
-    class Media:
-        """Necessary to use AutocompleteFilter."""
-
 
 @admin.register(Answer)
 class AnswerAdmin(admin.ModelAdmin):
@@ -212,6 +209,3 @@ class AnswerAdmin(admin.ModelAdmin):
         response = HttpResponse(content.getvalue(), content_type="application/x-zip-compressed")
         response["Content-Disposition"] = "attachment; filename=submissions.csv"
         return response
-
-    class Media:
-        """Necessary to use AutocompleteFilter."""

--- a/website/registrations/admin.py
+++ b/website/registrations/admin.py
@@ -247,9 +247,6 @@ class UserAdmin(admin.ModelAdmin):
         ]
         return custom_urls + urls
 
-    class Media:
-        """Necessary to use AutocompleteFilter."""
-
 
 class CsvImportForm(forms.Form):
     """Form used when importing a csv group assignment."""


### PR DESCRIPTION
### Description
<!-- Describe in detail why this pull request is needed. -->
Since [this PR](https://github.com/farhan0581/django-admin-autocomplete-filter/pull/34) the (empty) Media classes are no longer necessary.
