### PR TITLE
Temporarily add FILE_CHARSET

### DIFF
--- a/website/giphousewebsite/settings/base.py
+++ b/website/giphousewebsite/settings/base.py
@@ -149,3 +149,6 @@ GSUITE_SCOPES = [
     "https://www.googleapis.com/auth/admin.directory.group",
     "https://www.googleapis.com/auth/apps.groups.settings",
 ]
+
+# Temporarily add setting until all third-party upstreams are fixed.
+FILE_CHARSET = 'utf-8'


### PR DESCRIPTION
### Description
<!-- Describe in one sentence what this pull request accomplishes. -->
This temporarily adds `FILE_CHARSET`, a setting that is removed in Django 3.1. Once it is not used in any third-party library we use anymore, we should remove it.