### PR TITLE
Remove FILE_CHARSET from settings

### DIFF
--- a/website/giphousewebsite/settings/base.py
+++ b/website/giphousewebsite/settings/base.py
@@ -149,6 +149,3 @@ GSUITE_SCOPES = [
     "https://www.googleapis.com/auth/admin.directory.group",
     "https://www.googleapis.com/auth/apps.groups.settings",
 ]
-
-# Temporarily add setting until all third-party upstreams are fixed.
-FILE_CHARSET = 'utf-8'


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #484 

### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Because of https://github.com/jrief/django-sass-processor/pull/139, we can remove the `FILE_CHARSET` setting.
