### PR TITLE
Log users out before registration

### DIFF
--- a/website/registrations/tests/test_views.py
+++ b/website/registrations/tests/test_views.py
@@ -43,11 +43,15 @@ class Step1Test(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_step1_authenticated(self):
+        semester = Semester.objects.get_or_create_current_semester()
+        semester.registration_start = timezone.now()
+        semester.registration_end = timezone.now() + timezone.timedelta(days=1)
+        semester.save()
+
         self.client.force_login(self.test_user)
 
         response = self.client.get("/register/step1")
-
-        self.assertRedirects(response, reverse("home"))
+        self.assertFalse(response.context["user"].is_authenticated)
 
     def test_step1_no_semester(self):
         response = self.client.get("/register/step1", follow=True)

--- a/website/registrations/views.py
+++ b/website/registrations/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.contrib.auth import get_user_model, login
+from django.contrib.auth import get_user_model, login, logout
 from django.db import transaction
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
@@ -27,13 +27,12 @@ class Step1View(TemplateView):
 
     def dispatch(self, request, *args, **kwargs):
         """Check whether user is authenticated and if registration is possible."""
-        if request.user.is_authenticated:
-            messages.warning(request, "You are already logged in", extra_tags="success")
-            return redirect("home")
-
         if not Semester.objects.get_first_semester_with_open_registration():
             messages.warning(request, "Registrations are currently not open", extra_tags="danger")
             return redirect("home")
+
+        if request.user.is_authenticated:
+            logout(request)
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
### Description
<!-- Describe in detail why this pull request is needed. -->
Users should be able to register for a second semester (e.g. if they are taking a second GiPHouse course). It is confusing that you are redirected to the home page if you are still logged in and need to register for the new course. That is why all users are logged out, when they are registering.