### PR TITLE
Remove number of users column from mailinglists admin

### DIFF
--- a/website/mailing_lists/admin.py
+++ b/website/mailing_lists/admin.py
@@ -46,7 +46,7 @@ class MailingListAdmin(admin.ModelAdmin):
     """Admin class for Mailing List."""
 
     form = MailingListAdminForm
-    list_display = ("address", "description", "number_of_users", "mailinglist_aliases")
+    list_display = ("address", "description", "mailinglist_aliases")
     list_filter = ("address",)
     readonly_fields = ("gsuite_group_name",)
     inlines = [CourseSemesterLinkInline, ExtraEmailInline, AliasInline]

--- a/website/mailing_lists/models.py
+++ b/website/mailing_lists/models.py
@@ -78,11 +78,6 @@ class MailingList(models.Model):
         return set(course_emails + project_emails + user_emails + extra_emails)
 
     @property
-    def number_of_users(self):
-        """Return number of users currently in a mailing list."""
-        return self.users.count()
-
-    @property
     def mailinglist_aliases(self):
         """Return the alias of a mailinglist."""
         aliaslist = [

--- a/website/mailing_lists/tests/test_models.py
+++ b/website/mailing_lists/tests/test_models.py
@@ -133,11 +133,6 @@ class ModelTest(TestCase):
         mailinglist.delete()
         self.assertTrue(MailingListToBeDeleted.objects.filter(address="signal_list").exists())
 
-    def test_number_of_users(self):
-        mailing_list = MailingList.objects.create(address="signal_list")
-        mailing_list.save()
-        self.assertEqual(0, mailing_list.number_of_users)
-
     def test_mailinglist_aliases_empty(self):
         mailing_list = MailingList.objects.create(address="signal_list")
         self.assertEqual("-", mailing_list.mailinglist_aliases)


### PR DESCRIPTION
### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
The number of users property is confusing, because it does not list all mailinglists.