### PR TITLE
Fix GitHub auth

### DIFF
--- a/website/projects/githubsync.py
+++ b/website/projects/githubsync.py
@@ -27,11 +27,11 @@ class GitHubAPITalker:
         self._github = Github()  # used to talk to GitHub as our own app
 
         if (
-            settings.DJANGO_GITHUB_SYNC_APP_ID != "" and settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY_BASE64 != ""
+            settings.DJANGO_GITHUB_SYNC_APP_ID != "" and settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY != ""
         ):  # pragma: no cover
             self._gi = GithubIntegration(
                 auth=Auth.AppAuth(
-                    settings.DJANGO_GITHUB_SYNC_APP_ID, settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY_BASE64
+                    settings.DJANGO_GITHUB_SYNC_APP_ID, settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY
                 )
             )
         else:
@@ -63,7 +63,7 @@ class GitHubAPITalker:
 
         :except: GithubException when requesting a new access token fails
         """
-        if self._access_token is None or self._access_token.expires_at < datetime.utcnow() + timedelta(seconds=60):
+        if self._access_token is None or self._access_token.expires_at < datetime.now() + timedelta(seconds=60):
             self._access_token = self._gi.get_access_token(self.installation_id)
             self._github = Github(self._access_token.token)
             self._organization = self._github.get_organization(self.organization_name)

--- a/website/projects/tests/test_githubsync.py
+++ b/website/projects/tests/test_githubsync.py
@@ -311,35 +311,35 @@ class GitHubSyncTest(TestCase):
         self.remove_users_not_in_team(self.employee1.github_username, "member")
         self.github_team.remove_membership.assert_not_called()
         self.talker.remove_user.assert_not_called()
-        self.assertEquals(self.sync.users_removed, 0)
+        self.assertEqual(self.sync.users_removed, 0)
         self.assert_no_log()
 
     def test_remove_users_not_in_team__no_employee(self):
         self.remove_users_not_in_team("anunwanteduser", "member")
         self.github_team.remove_membership.assert_not_called()
         self.talker.remove_user.assert_called_once_with(self.github_user)
-        self.assertEquals(self.sync.users_removed, 1)
+        self.assertEqual(self.sync.users_removed, 1)
         self.assert_info()
 
     def test_remove_users_not_in_team__owner(self):
         self.remove_users_not_in_team("anunwanteduser", "admin")
         self.github_team.remove_membership.assert_called_once_with(self.github_user)
         self.talker.remove_user.assert_not_called()
-        self.assertEquals(self.sync.users_removed, 1)
+        self.assertEqual(self.sync.users_removed, 1)
         self.assert_info()
 
     def test_remove_users_not_in_team__exception_employee(self):
         self.remove_users_not_in_team("anunwanteduser", "member", self.exception, None)
         self.github_team.remove_membership.assert_not_called()
         self.talker.remove_user.assert_called_once_with(self.github_user)
-        self.assertEquals(self.sync.users_removed, 0)
+        self.assertEqual(self.sync.users_removed, 0)
         self.assert_error()
 
     def test_remove_users_not_in_team__exception_owner(self):
         self.remove_users_not_in_team("anunwanteduser", "admin", None, self.exception)
         self.github_team.remove_membership.assert_called_once_with(self.github_user)
         self.talker.remove_user.assert_not_called()
-        self.assertEquals(self.sync.users_removed, 0)
+        self.assertEqual(self.sync.users_removed, 0)
         self.assert_error()
 
     def test_remove_team__user_in_employees(self):
@@ -527,7 +527,7 @@ class GitHubSyncTest(TestCase):
         self.talker.create_repo.return_value = "ThisShouldBeAPyGithubRepo"
         returned_repo = self.sync.create_repo(self.repo1)
         self.talker.create_repo.assert_called_once_with(self.repo1)
-        self.assertEquals(returned_repo, "ThisShouldBeAPyGithubRepo")
+        self.assertEqual(returned_repo, "ThisShouldBeAPyGithubRepo")
         self.github_team.add_to_repos.assert_called_once_with(returned_repo)
         self.github_team.set_repo_permission.assert_called_once_with(returned_repo, "admin")
 


### PR DESCRIPTION
### Description
<!-- Specify the issue this pull request closes, if any. -->
This should fix the following issue in the logs: jwt.exceptions.InvalidKeyError: Could not parse the provided public key
I believe the base64 encoding breaks the jwt encoder which makes it break to get a new key which in turn makes it impossible to sync.

