### PR TITLE
Fix my previous mistake

### DIFF
--- a/website/projects/githubsync.py
+++ b/website/projects/githubsync.py
@@ -27,11 +27,11 @@ class GitHubAPITalker:
         self._github = Github()  # used to talk to GitHub as our own app
 
         if (
-            settings.DJANGO_GITHUB_SYNC_APP_ID != "" and settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY_BASE64 != ""
+            settings.DJANGO_GITHUB_SYNC_APP_ID != "" and settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY.decode("utf_8") != ""
         ):  # pragma: no cover
             self._gi = GithubIntegration(
                 auth=Auth.AppAuth(
-                    settings.DJANGO_GITHUB_SYNC_APP_ID, settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY_BASE64
+                    settings.DJANGO_GITHUB_SYNC_APP_ID, settings.DJANGO_GITHUB_SYNC_APP_PRIVATE_KEY.decode("utf_8")
                 )
             )
         else:


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Fixes the issue that crashed the server.

### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Fixes the issue that crashed the server.

### Description
<!-- Describe in detail why this pull request is needed. -->
the key was apparently in byte notation and not in string notation I missed the b in both reading it on the server as well as copy pasting it while testing to get a working github access token.